### PR TITLE
refactor(flake): simplify flake structure and remove unused applet in…

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,130 +1,16 @@
 {
   "nodes": {
-    "cosmic-ext-applet-caffeine": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1750939778,
-        "narHash": "sha256-WEm2PVq7HrqtqGtIvEecpzJT35K+KMRf+IWrwE/mHQc=",
-        "owner": "tropicbliss",
-        "repo": "cosmic-ext-applet-caffeine",
-        "rev": "dffe4da8b8d63185267ff262776aae35e8dae426",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tropicbliss",
-        "repo": "cosmic-ext-applet-caffeine",
-        "type": "github"
-      }
-    },
-    "cosmic-ext-applet-clipboard-manager": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1754400182,
-        "narHash": "sha256-NLu4C/UA+4+fCahQx6IcA76ORMkHoUoZZThjWDSS2Hg=",
-        "owner": "cosmic-utils",
-        "repo": "clipboard-manager",
-        "rev": "3b4d392f8bae47d5582e308dac0296eeb7365c6a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cosmic-utils",
-        "repo": "clipboard-manager",
-        "type": "github"
-      }
-    },
-    "cosmic-ext-applet-emoji-selector": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1749757341,
-        "narHash": "sha256-BDI5tV6Gzbwtm6Vex46CYDpTqMupssOJUZU0YNGyIqM=",
-        "owner": "bGVia3VjaGVu",
-        "repo": "cosmic-ext-applet-emoji-selector",
-        "rev": "f7333f23b235121b2c85787f82d94bf8804c6b50",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bGVia3VjaGVu",
-        "repo": "cosmic-ext-applet-emoji-selector",
-        "type": "github"
-      }
-    },
-    "cosmic-ext-applet-weather": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1755966135,
-        "narHash": "sha256-VHCgMw4nWTKAbanEnMS/xCUzEW3NeWGmVkBqU2bJP/c=",
-        "owner": "cosmic-utils",
-        "repo": "cosmic-ext-applet-weather",
-        "rev": "f613c9dd156e84290765c34ca98ff8ede3b530fa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cosmic-utils",
-        "repo": "cosmic-ext-applet-weather",
-        "type": "github"
-      }
-    },
-    "cosmic-ext-bg-theme": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1753331757,
-        "narHash": "sha256-iqOA0n0LOpzVugyijKkyQVLoRyF9J8QpbeWCSaH4kIk=",
-        "owner": "wash2",
-        "repo": "cosmic_ext_bg_theme",
-        "rev": "3c338ef06e0e332a874e52ac0cc10c2a8d29a4f6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "wash2",
-        "repo": "cosmic_ext_bg_theme",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "minimon-applet": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1756683340,
-        "narHash": "sha256-FbbJPYotRHn85BV7p7wRSlAsPW1lSWrPCbEAgHq01QI=",
-        "owner": "cosmic-utils",
-        "repo": "minimon-applet",
-        "rev": "18371c94479e6598d5567a956285f398e76a1eb8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cosmic-utils",
-        "repo": "minimon-applet",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1756787288,
         "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
-        "owner": "NixOS",
+        "owner": "nixos",
         "repo": "nixpkgs",
         "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -132,29 +18,7 @@
     },
     "root": {
       "inputs": {
-        "cosmic-ext-applet-caffeine": "cosmic-ext-applet-caffeine",
-        "cosmic-ext-applet-clipboard-manager": "cosmic-ext-applet-clipboard-manager",
-        "cosmic-ext-applet-emoji-selector": "cosmic-ext-applet-emoji-selector",
-        "cosmic-ext-applet-weather": "cosmic-ext-applet-weather",
-        "cosmic-ext-bg-theme": "cosmic-ext-bg-theme",
-        "flake-utils": "flake-utils",
-        "minimon-applet": "minimon-applet",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,90 +1,49 @@
 {
-  description = "A nix flake for installing a number of 3rd party applets for the Cosmic Desktop";
+  description = "Flake template by Gurjaka";
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+
+    forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f nixpkgs.legacyPackages.${system});
+
+    flake_attributes = forAllSystems (pkgs: rec {
+      callPackage = name: pkgs.callPackage ./pkgs/${name}.nix {};
+
+      applets = {
+        cosmic-ext-applet-clipboard-manager = callPackage "cosmic-ext-applet-clipboard-manager";
+        cosmic-ext-applet-caffeine = callPackage "cosmic-ext-applet-caffeine";
+        cosmic-ext-applet-emoji-selector = callPackage "cosmic-ext-applet-emoji-selector";
+        minimon-applet = callPackage "minimon-applet";
+        cosmic-ext-applet-weather = callPackage "cosmic-ext-applet-weather";
+        cosmic-ext-bg-theme = callPackage "cosmic-ext-bg-theme";
+      };
+    });
+  in {
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+
+    packages = forAllSystems (
+      pkgs:
+        flake_attributes.${pkgs.system}.applets
+        // {
+          # Make all applets available as individual packages
+          # and create a default that includes all of them
+          default = pkgs.buildEnv {
+            name = "cosmic-applets-collection";
+            paths = builtins.attrValues flake_attributes.${pkgs.system}.applets;
+          };
+        }
+    );
+  };
 
   inputs = {
-    # Essential inputs for building packages
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-
-    # Applets
-    cosmic-ext-applet-clipboard-manager = {
-        url = "github:cosmic-utils/clipboard-manager";
-        flake = false;
-    };
-
-    cosmic-ext-applet-caffeine = {
-        url = "github:tropicbliss/cosmic-ext-applet-caffeine";
-        flake = false;
-    };
-
-    cosmic-ext-applet-emoji-selector = {
-        url = "github:bGVia3VjaGVu/cosmic-ext-applet-emoji-selector";
-        flake = false;
-    };
-
-    minimon-applet = {
-      url = "github:cosmic-utils/minimon-applet";
-      flake = false;
-    };
-
-    cosmic-ext-applet-weather = {
-      url = "github:cosmic-utils/cosmic-ext-applet-weather";
-      flake = false;
-    };
-
-    cosmic-ext-bg-theme = {
-      url = "github:wash2/cosmic_ext_bg_theme";
-      flake = false;
-    };
-
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
-  		
-  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        # Import nixpkgs for the given system
-        pkgs = import nixpkgs { inherit system; };
-
-        # Helper function to call packages from the ./pkgs directory
-        callPackage = name: pkgs.callPackage ./pkgs/${name}.nix {
-          # Pass the source for the package from the inputs
-          src = inputs."${name}";
-        };
-
-        # A set containing all your applet packages
-        applets = {
-          cosmic-ext-applet-clipboard-manager = callPackage "cosmic-ext-applet-clipboard-manager";
-          cosmic-ext-applet-caffeine = callPackage "cosmic-ext-applet-caffeine";
-          cosmic-ext-applet-emoji-selector = callPackage "cosmic-ext-applet-emoji-selector";
-          minimon-applet = callPackage "minimon-applet";
-          cosmic-ext-applet-weather = callPackage "cosmic-ext-applet-weather";
-          cosmic-ext-bg-theme = callPackage "cosmic-ext-bg-theme";
-        };
-      in
-      {
-        # Packages exposed for building and installing
-        # e.g., `nix build .#cosmic-ext-applet-caffeine`
-        packages = applets // {
-          # A default package that builds all applets
-          default = pkgs.symlinkJoin {
-            name = "cosmic-applets";
-            paths = builtins.attrValues applets;
-          };
-        };
-
-        # An overlay to easily add the applets to your system configuration
-        overlays.default = final: prev: {
-          cosmic-applets = applets;
-        };
-        
-        # A dev shell for working on the packages
-        devShells.default = pkgs.mkShell {
-          packages = builtins.attrValues applets ++ [
-            pkgs.rustc
-            pkgs.cargo
-            pkgs.pkg-config
-          ];
-        };
-      });      
 }
-


### PR DESCRIPTION
…puts

- Removed multiple Cosmic applet inputs from `flake.lock` and `flake.nix`
- Replaced `flake-utils` based system handling with custom `forAllSystems` approach
- Updated `nixpkgs` owner from `NixOS` to `nixos`
- Added `formatter` output using `alejandra`
- Consolidated package definitions into `flake_attributes` for all supported systems
- Introduced `buildEnv` to create a `default` package bundling all applets
- Reduced inputs to only `nixpkgs`