### PR TITLE
nixpkgs/cosmic: add and modernize COSMIC applets

### DIFF
--- a/pkgs/cosmic-ext-applet-caffeine.nix
+++ b/pkgs/cosmic-ext-applet-caffeine.nix
@@ -1,42 +1,34 @@
-{ lib, stdenv, rustPlatform, pkg-config, src, just, libcosmicAppHook, nix-update-script }:
-
-rustPlatform.buildRustPackage rec {
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libxkbcommon,
+}:
+rustPlatform.buildRustPackage {
   pname = "cosmic-ext-applet-caffeine";
-  version = "0.1.0";
+  version = "unstable-2025-03-10";
 
-  inherit src;
-
-  cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    hash = "sha256-Ynqb71OnHULvouvulBKQBo41j61aQpLoHnCJwJihTrY=";
+  src = fetchFromGitHub {
+    owner = "tropicbliss";
+    repo = "cosmic-ext-applet-caffeine";
+    rev = "dd52bc2974372bd2c4da49935aab0c108012580a";
+    hash = "sha256-klaqJkigfzWokVVC2UWefE6AVvcrOi1Izvpc5FUxMGo=";
   };
 
-  nativeBuildInputs = [
-    pkg-config
-    just
-    libcosmicAppHook
-  ];
+  cargoHash = "sha256-xTJwVus28p7rNbfYRANo1UYkXDvwOc4ozuu+kPM3GDI=";
 
-  # This package uses a `justfile` for its build process instead of raw cargo commands.
-  # These flags replicate the logic from the working example.
-  dontUseJustBuild = true;
-  dontUseJustCheck = true;
+  nativeBuildInputs = [pkg-config];
+  buildInputs = [libxkbcommon];
 
-  justFlags = [
-    "--set" "prefix" (placeholder "out")
-    "--set" "bin-src" "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-ext-applet-caffeine"
-  ];
-
-  passthru.updateScript = nix-update-script { };
-
-  meta = with lib; {
-    description = "Caffeine Applet for the COSMIC desktop";
-    homepage = "https://github.com/tropicbliss/cosmic-ext-applet-caffeine";
-    # The repository's LICENSE file specifies GPLv3.
-    license = licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ];
-    platforms = platforms.linux;
+  meta = {
+    description = "Caffeine Applet for the COSMIC™ desktop";
+    homepage = "https://github.com/tropicbliss/cosmic-ext-applet-caffeine/tree/main";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      wingej0
+      gurjaka
+    ];
     mainProgram = "cosmic-ext-applet-caffeine";
   };
 }
-

--- a/pkgs/cosmic-ext-applet-clipboard-manager.nix
+++ b/pkgs/cosmic-ext-applet-clipboard-manager.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libxkbcommon,
+  sqlite,
+  vulkan-loader,
+  stdenv,
+  darwin,
+  wayland,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "cosmic-ext-applet-clipboard-manager";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "cosmic-utils";
+    repo = "clipboard-manager";
+    rev = version;
+    hash = "sha256-TcTb3wFqw/WaxVsb4azqQAtc8unlc8xLXiupeiakxVg=";
+  };
+
+  cargoHash = "sha256-mFr2Zb48yKiv60UHBu9ZdbmR4X52Rp6HT8wGyxPpyYI=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      libxkbcommon
+      sqlite
+      vulkan-loader
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.AppKit
+      darwin.apple_sdk.frameworks.CoreFoundation
+      darwin.apple_sdk.frameworks.CoreGraphics
+      darwin.apple_sdk.frameworks.CoreServices
+      darwin.apple_sdk.frameworks.Foundation
+      darwin.apple_sdk.frameworks.Metal
+      darwin.apple_sdk.frameworks.QuartzCore
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      wayland
+    ];
+
+  meta = {
+    description = "Clipboard manager for COSMIC";
+    homepage = "https://github.com/cosmic-utils/clipboard-manager";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      wingej0
+      gurjaka
+    ];
+    mainProgram = "cosmic-ext-applet-clipboard-manager";
+  };
+}

--- a/pkgs/cosmic-ext-applet-emoji-selector.nix
+++ b/pkgs/cosmic-ext-applet-emoji-selector.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook,
+  atk,
+  cairo,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libxkbcommon,
+  pango,
+  vulkan-loader,
+  stdenv,
+  darwin,
+  wayland,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "cosmic-ext-applet-emoji-selector";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "bGVia3VjaGVu";
+    repo = "cosmic-ext-applet-emoji-selector";
+    rev = "v${version}";
+    hash = "sha256-tUfrurThxN++cZiCyVHr65qRne9ZXzWtMuPb0lqOijE=";
+  };
+
+  cargoHash = "sha256-vI8pIOo8A9Ebyati4c0CyGxuf4YQKEaSdG28CQ1/w3w=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs =
+    [
+      atk
+      cairo
+      gdk-pixbuf
+      glib
+      gtk3
+      libxkbcommon
+      pango
+      vulkan-loader
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.AppKit
+      darwin.apple_sdk.frameworks.CoreFoundation
+      darwin.apple_sdk.frameworks.CoreGraphics
+      darwin.apple_sdk.frameworks.CoreServices
+      darwin.apple_sdk.frameworks.Foundation
+      darwin.apple_sdk.frameworks.Metal
+      darwin.apple_sdk.frameworks.QuartzCore
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      wayland
+    ];
+
+  meta = {
+    description = "Emoji Selector for COSMIC™\u{fe0f} DE";
+    homepage = "https://github.com/bGVia3VjaGVu/cosmic-ext-applet-emoji-selector";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      wingej0
+      gurjaka
+    ];
+    mainProgram = "cosmic-ext-applet-emoji-selector";
+  };
+}

--- a/pkgs/cosmic-ext-applet-weather.nix
+++ b/pkgs/cosmic-ext-applet-weather.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libxkbcommon,
+}:
+rustPlatform.buildRustPackage {
+  pname = "cosmic-ext-applet-weather";
+  version = "unstable-2025-08-23";
+
+  src = fetchFromGitHub {
+    owner = "cosmic-utils";
+    repo = "cosmic-ext-applet-weather";
+    rev = "f613c9dd156e84290765c34ca98ff8ede3b530fa";
+    hash = "sha256-VHCgMw4nWTKAbanEnMS/xCUzEW3NeWGmVkBqU2bJP/c=";
+  };
+
+  cargoHash = "sha256-CS4P1DHzTmkZdANw6UQsB0kjKTeaf3cAQ/2EiPHSg7g=";
+
+  nativeBuildInputs = [pkg-config];
+  buildInputs = [libxkbcommon];
+
+  meta = {
+    description = "Simple weather info applet for cosmic";
+    homepage = "https://github.com/cosmic-utils/cosmic-ext-applet-weather";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      wingej0
+      gurjaka
+    ];
+    mainProgram = "cosmic-ext-applet-weather";
+  };
+}

--- a/pkgs/cosmic-ext-bg-theme.nix
+++ b/pkgs/cosmic-ext-bg-theme.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libxkbcommon,
+  stdenv,
+  darwin,
+  wayland,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "cosmic-ext-bg-theme";
+  version = "unstable-2025-07-24";
+
+  src = fetchFromGitHub {
+    owner = "wash2";
+    repo = "cosmic_ext_bg_theme";
+    rev = "3c338ef06e0e332a874e52ac0cc10c2a8d29a4f6";
+    hash = "sha256-iqOA0n0LOpzVugyijKkyQVLoRyF9J8QpbeWCSaH4kIk=";
+  };
+
+  cargoHash = "sha256-6R9JY55fEKGrByCJzR3Ifan03MsVYusMonMPZzCXqHc=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      libxkbcommon
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.AppKit
+      darwin.apple_sdk.frameworks.CoreFoundation
+      darwin.apple_sdk.frameworks.CoreServices
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      wayland
+    ];
+
+  meta = {
+    description = "";
+    homepage = "https://github.com/wash2/cosmic_ext_bg_theme";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      wingej0
+      gurjaka
+    ];
+    mainProgram = "cosmic-ext-bg-theme";
+  };
+}

--- a/pkgs/minimon-applet.nix
+++ b/pkgs/minimon-applet.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libxkbcommon,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "minimon-applet";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "cosmic-utils";
+    repo = "minimon-applet";
+    rev = "v${version}";
+    hash = "sha256-TK+H9HUgJZxVwcxhot+Jsbs7ZnBBtu5p5xXEahzs298=";
+  };
+
+  cargoHash = "sha256-vNmySJ/bmSPpEHgIGTqs5Lf4GrhRfD6JdqVv+renUy8=";
+
+  nativeBuildInputs = [pkg-config];
+  buildInputs = [libxkbcommon];
+
+  meta = {
+    description = "A COSMIC applet for displaying CPU/Memory/Network/Disk/GPU usage in the Panel or Dock";
+    homepage = "https://github.com/cosmic-utils/minimon-applet";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      wingej0
+      gurjaka
+    ];
+    mainProgram = "minimon-applet";
+  };
+}


### PR DESCRIPTION
- Update `cosmic-ext-applet-caffeine` to fetch directly from GitHub, use proper cargoHash, simplify build inputs, and switch license to MIT.
- Add new applets:
  - `cosmic-ext-applet-clipboard-manager` 0.1.0
  - `cosmic-ext-applet-emoji-selector` 0.1.5
  - `cosmic-ext-applet-weather` unstable-2025-08-23
  - `cosmic-ext-bg-theme` unstable-2025-07-24
  - `minimon-applet` 0.8.0
- Standardize maintainers across all applets to `wingej0` and `gurjaka`.
- Ensure platform-specific buildInputs for Linux (Wayland) and macOS (Apple SDKs) where needed.